### PR TITLE
Rename and expand readme for DFHack docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# justscripts
-Just like it says on the box, just scripts yo!

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,47 @@
+==================
+maxthyme's scripts
+==================
+
+.. todo
+    
+    Someone familiar with the script to fill out and check this readme!
+
+launch
+======
+Activate with a cursor on screen and you will go there rapidly, attack 
+something first to send them there.  Based on ``propel.lua`` by Roses.
+
+names
+=====
+Rename units or items.  Usage:
+
+:-help:     print this help message
+:-item:     if viewing an item
+:-unit:     if viewing a unit
+:-first [Somename | "Some Names like This":
+            if a first name is desired, leave blank to clear current first name
+
+prefchange
+==========
+Sets preferences for mooding to include a weapon type, equipment type,
+and material.  If you also wish to trigger a mood, see
+`plugins/strangemood`.
+
+Valid options:
+
+:show:  show preferences of all units
+:c:     clear preferences of selected unit
+:all:   clear preferences of all units
+:axp:   likes axes, breastplates, and steel
+:has:   likes hammers, mail shirts, and steel
+:swb:   likes short swords, high boots, and steel
+:spb:   likes spears, high boots, and steel
+:mas:   likes maces, shields, and steel
+:xbh:   likes crossbows, helms, and steel
+:pig:   likes picks, gauntlets, and steel
+:log:   likes long swords, gauntlets, and steel
+:dap:   likes daggers, greaves, and steel
+
+Feel free to adjust the values as you see fit, change the has steel to
+platinum, change the axp axes to great axes, whatnot.
+


### PR DESCRIPTION
The new build process with Sphinx can pull in other .rst format documentation, and we've got it set up to do this as of DFHack pull 697.

Expanding the README means these scripts will be documented with DFHack, as well as distributed with DFHack.
